### PR TITLE
✅test: Lambda関数のユニットテストを追加

### DIFF
--- a/packages/cdk/jest.config.js
+++ b/packages/cdk/jest.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   testEnvironment: 'node',
   roots: ['<rootDir>/test'],
-  testMatch: ['**/*.test.ts'],
+  testMatch: ['**/*.test.ts', '**/*.test.js'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-  },
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  }
 };

--- a/packages/cdk/test/lambda/close-room.test.js
+++ b/packages/cdk/test/lambda/close-room.test.js
@@ -1,0 +1,181 @@
+const { handler } = require('../../lambda/close-room/index');
+const { mockClient } = require('aws-sdk-client-mock');
+const { DynamoDBDocumentClient, UpdateCommand, GetCommand } = require('@aws-sdk/lib-dynamodb');
+
+// モックの設定
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+// テストの前に実行
+beforeEach(() => {
+  // モックをリセット
+  ddbMock.reset();
+  // 環境変数を設定
+  process.env.ROOMS_TABLE = 'test-rooms-table';
+});
+
+describe('close-room Lambda function', () => {
+  test('正常に部屋が閉じられる', async () => {
+    // 部屋の情報を取得するGetCommandのモックを設定
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        roomId: 'test-room-123',
+        name: 'テスト部屋',
+        hostId: 'test-host-123',
+        status: 'OPEN',
+        createdAt: '2025-04-19T12:00:00Z'
+      }
+    });
+
+    // 部屋のステータスを更新するUpdateCommandのモックを設定
+    ddbMock.on(UpdateCommand).resolves({});
+
+    // テストデータ
+    const event = {
+      pathParameters: {
+        roomId: 'test-room-123'
+      },
+      body: JSON.stringify({
+        hostId: 'test-host-123'
+      })
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // レスポンスを検証
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.roomId).toBe('test-room-123');
+    expect(body.status).toBe('CLOSED');
+    expect(body.updatedAt).toBeDefined();
+
+    // GetCommandの呼び出しを検証
+    const getCalls = ddbMock.commandCalls(GetCommand);
+    expect(getCalls.length).toBe(1);
+    expect(getCalls[0].args[0].input.TableName).toBe('test-rooms-table');
+    expect(getCalls[0].args[0].input.Key.roomId).toBe('test-room-123');
+
+    // UpdateCommandの呼び出しを検証
+    const updateCalls = ddbMock.commandCalls(UpdateCommand);
+    expect(updateCalls.length).toBe(1);
+    expect(updateCalls[0].args[0].input.TableName).toBe('test-rooms-table');
+    expect(updateCalls[0].args[0].input.Key.roomId).toBe('test-room-123');
+    expect(updateCalls[0].args[0].input.UpdateExpression).toBe('SET #status = :status, updatedAt = :updatedAt');
+    expect(updateCalls[0].args[0].input.ExpressionAttributeValues[':status']).toBe('CLOSED');
+  });
+
+  test('存在しない部屋を閉じようとするとエラーになる', async () => {
+    // 部屋が存在しないケース
+    ddbMock.on(GetCommand).resolves({
+      Item: null
+    });
+
+    // テストデータ
+    const event = {
+      pathParameters: {
+        roomId: 'non-existent-room'
+      },
+      body: JSON.stringify({
+        hostId: 'test-host-123'
+      })
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(404);
+    const body = JSON.parse(result.body);
+    expect(body.message).toContain('Room not found');
+  });
+
+  test('別のホストが部屋を閉じようとするとエラーになる', async () => {
+    // 別のホストIDの部屋が存在するケース
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        roomId: 'test-room-123',
+        name: 'テスト部屋',
+        hostId: 'different-host-123', // リクエストとは異なるホストID
+        status: 'OPEN',
+        createdAt: '2025-04-19T12:00:00Z'
+      }
+    });
+
+    // テストデータ
+    const event = {
+      pathParameters: {
+        roomId: 'test-room-123'
+      },
+      body: JSON.stringify({
+        hostId: 'test-host-123' // 部屋のホストとは異なるID
+      })
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(403);
+    const body = JSON.parse(result.body);
+    expect(body.message).toContain('Forbidden');
+  });
+
+  test('roomIdが指定されていない場合はエラーを返す', async () => {
+    // テストデータ（roomIdが指定されていない）
+    const event = {
+      pathParameters: {},
+      body: JSON.stringify({
+        hostId: 'test-host-123'
+      })
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.message).toContain('Missing required parameter: roomId');
+  });
+
+  test('hostIdが指定されていない場合はエラーを返す', async () => {
+    // テストデータ（hostIdが指定されていない）
+    const event = {
+      pathParameters: {
+        roomId: 'test-room-123'
+      },
+      body: JSON.stringify({})
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.message).toContain('Missing required parameter: hostId');
+  });
+
+  test('DynamoDB例外が発生した場合はエラーを返す', async () => {
+    // DynamoDBのGetCommandが例外をスローするようにモックを設定
+    ddbMock.on(GetCommand).rejects(new Error('DB Error'));
+
+    // テストデータ
+    const event = {
+      pathParameters: {
+        roomId: 'test-room-123'
+      },
+      body: JSON.stringify({
+        hostId: 'test-host-123'
+      })
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(500);
+    const body = JSON.parse(result.body);
+    expect(body.message).toBe('Internal server error');
+  });
+});

--- a/packages/cdk/test/lambda/connect.test.js
+++ b/packages/cdk/test/lambda/connect.test.js
@@ -1,0 +1,54 @@
+const { handler } = require('../../lambda/connect/index');
+
+describe('connect Lambda function', () => {
+  test('正常に接続が受け入れられる', async () => {
+    // コンソールログのスパイを作成
+    const consoleSpy = jest.spyOn(console, 'log');
+
+    // テストデータ
+    const event = {
+      requestContext: {
+        connectionId: 'test-connection-id-123',
+        eventType: 'CONNECT',
+        connectedAt: 1617990000000
+      }
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // レスポンスを検証
+    expect(result.statusCode).toBe(200);
+
+    // コンソールログの呼び出しを検証
+    expect(consoleSpy).toHaveBeenCalledWith('Connect requested for:', 'test-connection-id-123');
+
+    // スパイをリストア
+    consoleSpy.mockRestore();
+  });
+
+  test('接続IDなしでも正常に処理される', async () => {
+    // コンソールログのスパイを作成
+    const consoleSpy = jest.spyOn(console, 'log');
+
+    // テストデータ（接続IDなし）
+    const event = {
+      requestContext: {
+        eventType: 'CONNECT',
+        connectedAt: 1617990000000
+      }
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // レスポンスを検証
+    expect(result.statusCode).toBe(200);
+
+    // コンソールログの呼び出しを検証
+    expect(consoleSpy).toHaveBeenCalledWith('Connect requested for:', undefined);
+
+    // スパイをリストア
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/cdk/test/lambda/disconnect.test.js
+++ b/packages/cdk/test/lambda/disconnect.test.js
@@ -1,0 +1,72 @@
+const { handler } = require('../../lambda/disconnect/index');
+const { mockClient } = require('aws-sdk-client-mock');
+const { DynamoDBDocumentClient, DeleteCommand } = require('@aws-sdk/lib-dynamodb');
+
+// モックの設定
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+// テストの前に実行
+beforeEach(() => {
+  // モックをリセット
+  ddbMock.reset();
+  // 環境変数を設定
+  process.env.CONNECTIONS_TABLE = 'test-connections-table';
+});
+
+describe('disconnect Lambda function', () => {
+  test('正常に接続が削除される', async () => {
+    // DynamoDBのDeleteCommandのモックを設定
+    ddbMock.on(DeleteCommand).resolves({});
+
+    // テストデータ
+    const event = {
+      requestContext: {
+        connectionId: 'test-connection-id-123',
+        eventType: 'DISCONNECT',
+        disconnectedAt: 1617990000000
+      }
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // レスポンスを検証
+    expect(result.statusCode).toBe(200);
+
+    // DynamoDBの削除パラメータを検証
+    const deleteCalls = ddbMock.commandCalls(DeleteCommand);
+    expect(deleteCalls.length).toBe(1);
+    const deleteCall = deleteCalls[0];
+    expect(deleteCall.args[0].input.TableName).toBe('test-connections-table');
+    expect(deleteCall.args[0].input.Key.connectionId).toBe('test-connection-id-123');
+  });
+
+  test('DynamoDB例外が発生した場合はエラーを返す', async () => {
+    // コンソールエラーのスパイを作成
+    const consoleSpy = jest.spyOn(console, 'error');
+
+    // DynamoDBのDeleteCommandが例外をスローするようにモックを設定
+    ddbMock.on(DeleteCommand).rejects(new Error('DB Error'));
+
+    // テストデータ
+    const event = {
+      requestContext: {
+        connectionId: 'test-connection-id-123',
+        eventType: 'DISCONNECT',
+        disconnectedAt: 1617990000000
+      }
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(500);
+
+    // コンソールエラーの呼び出しを検証
+    expect(consoleSpy).toHaveBeenCalledWith('Error disconnecting:', expect.any(Error));
+
+    // スパイをリストア
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/cdk/test/lambda/get-room-comments.test.js
+++ b/packages/cdk/test/lambda/get-room-comments.test.js
@@ -1,0 +1,100 @@
+const { handler } = require('../../lambda/get-room-comments/index');
+const { mockClient } = require('aws-sdk-client-mock');
+const { DynamoDBDocumentClient, QueryCommand } = require('@aws-sdk/lib-dynamodb');
+
+// モックの設定
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+// テストの前に実行
+beforeEach(() => {
+  // モックをリセット
+  ddbMock.reset();
+  // 環境変数を設定
+  process.env.COMMENTS_TABLE = 'test-comments-table';
+});
+
+describe('get-room-comments Lambda function', () => {
+  test('正常にコメントリストが取得される', async () => {
+    // テスト用のコメントデータ
+    const mockComments = [
+      {
+        roomId: 'test-room-123',
+        commentId: 'comment-1',
+        content: 'テストコメント1',
+        nickname: 'ユーザー1',
+        createdAt: '2025-04-19T12:00:00Z'
+      },
+      {
+        roomId: 'test-room-123',
+        commentId: 'comment-2',
+        content: 'テストコメント2',
+        nickname: 'ユーザー2',
+        createdAt: '2025-04-19T12:01:00Z'
+      }
+    ];
+
+    // DynamoDBのQueryCommandのモックを設定
+    ddbMock.on(QueryCommand).resolves({
+      Items: mockComments
+    });
+
+    // テストデータ
+    const event = {
+      pathParameters: {
+        roomId: 'test-room-123'
+      }
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // レスポンスを検証
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.roomId).toBe('test-room-123');
+    expect(body.comments).toEqual(mockComments);
+
+    // DynamoDBのクエリパラメータを検証
+    const queryCalls = ddbMock.commandCalls(QueryCommand);
+    expect(queryCalls.length).toBe(1);
+    const queryCall = queryCalls[0];
+    expect(queryCall.args[0].input.TableName).toBe('test-comments-table');
+    expect(queryCall.args[0].input.KeyConditionExpression).toBe('roomId = :roomId');
+    expect(queryCall.args[0].input.ExpressionAttributeValues[':roomId']).toBe('test-room-123');
+  });
+
+  test('roomIdが指定されていない場合はエラーを返す', async () => {
+    // テストデータ（roomIdが指定されていない）
+    const event = {
+      pathParameters: {}
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.message).toContain('Missing required parameter');
+  });
+
+  test('DynamoDB例外が発生した場合はエラーを返す', async () => {
+    // DynamoDBのQueryCommandが例外をスローするようにモックを設定
+    ddbMock.on(QueryCommand).rejects(new Error('DB Error'));
+
+    // テストデータ
+    const event = {
+      pathParameters: {
+        roomId: 'test-room-123'
+      }
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(500);
+    const body = JSON.parse(result.body);
+    expect(body.message).toBe('Internal server error');
+  });
+});

--- a/packages/cdk/test/lambda/get-user-rooms.test.js
+++ b/packages/cdk/test/lambda/get-user-rooms.test.js
@@ -1,0 +1,136 @@
+const { handler } = require('../../lambda/get-user-rooms/index');
+const { mockClient } = require('aws-sdk-client-mock');
+const { DynamoDBDocumentClient, ScanCommand } = require('@aws-sdk/lib-dynamodb');
+
+// モックの設定
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+// テストの前に実行
+beforeEach(() => {
+  // モックをリセット
+  ddbMock.reset();
+  // 環境変数を設定
+  process.env.ROOMS_TABLE = 'test-rooms-table';
+});
+
+describe('get-user-rooms Lambda function', () => {
+  test('正常にユーザーの部屋リストが取得される', async () => {
+    // テスト用の部屋データ
+    const mockRooms = [
+      {
+        roomId: 'room-1',
+        name: 'テスト部屋1',
+        hostId: 'test-host-123',
+        status: 'OPEN',
+        createdAt: '2025-04-19T12:00:00Z'
+      },
+      {
+        roomId: 'room-2',
+        name: 'テスト部屋2',
+        hostId: 'test-host-123',
+        status: 'CLOSED',
+        createdAt: '2025-04-19T13:00:00Z'
+      }
+    ];
+
+    // DynamoDBのScanCommandのモックを設定
+    ddbMock.on(ScanCommand).resolves({
+      Items: mockRooms
+    });
+
+    // テストデータ
+    const event = {
+      queryStringParameters: {
+        hostId: 'test-host-123'
+      }
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // レスポンスを検証
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.rooms).toEqual(mockRooms);
+
+    // DynamoDBのスキャンパラメータを検証
+    const scanCalls = ddbMock.commandCalls(ScanCommand);
+    expect(scanCalls.length).toBe(1);
+    const scanCall = scanCalls[0];
+    expect(scanCall.args[0].input.TableName).toBe('test-rooms-table');
+    expect(scanCall.args[0].input.FilterExpression).toBe('hostId = :hostId');
+    expect(scanCall.args[0].input.ExpressionAttributeValues[':hostId']).toBe('test-host-123');
+  });
+
+  test('hostIdが指定されていない場合はエラーを返す', async () => {
+    // テストデータ（hostIdが指定されていない）
+    const event = {
+      queryStringParameters: {}
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.message).toContain('Missing required parameter');
+  });
+
+  test('queryStringParametersがnullの場合はエラーを返す', async () => {
+    // テストデータ（queryStringParametersがnull）
+    const event = {
+      queryStringParameters: null
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.message).toContain('Missing required parameter');
+  });
+
+  test('ユーザーが部屋を持っていない場合は空リストを返す', async () => {
+    // DynamoDBのScanCommandのモックを設定（空のリスト）
+    ddbMock.on(ScanCommand).resolves({
+      Items: []
+    });
+
+    // テストデータ
+    const event = {
+      queryStringParameters: {
+        hostId: 'test-host-123'
+      }
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // レスポンスを検証
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.rooms).toEqual([]);
+  });
+
+  test('DynamoDB例外が発生した場合はエラーを返す', async () => {
+    // DynamoDBのScanCommandが例外をスローするようにモックを設定
+    ddbMock.on(ScanCommand).rejects(new Error('DB Error'));
+
+    // テストデータ
+    const event = {
+      queryStringParameters: {
+        hostId: 'test-host-123'
+      }
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(500);
+    const body = JSON.parse(result.body);
+    expect(body.message).toBe('Internal server error');
+  });
+});

--- a/packages/cdk/test/lambda/join-room.test.js
+++ b/packages/cdk/test/lambda/join-room.test.js
@@ -1,0 +1,148 @@
+const { handler } = require('../../lambda/join-room/index');
+const { mockClient } = require('aws-sdk-client-mock');
+const { DynamoDBDocumentClient, PutCommand, GetCommand } = require('@aws-sdk/lib-dynamodb');
+
+// モックの設定
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+// テストの前に実行
+beforeEach(() => {
+  // モックをリセット
+  ddbMock.reset();
+  // 環境変数を設定
+  process.env.ROOMS_TABLE = 'test-rooms-table';
+  process.env.CONNECTIONS_TABLE = 'test-connections-table';
+});
+
+describe('join-room Lambda function', () => {
+  test('正常に部屋に参加できる', async () => {
+    // 部屋の情報を取得するGetCommandのモックを設定
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        roomId: 'test-room-123',
+        name: 'テスト部屋',
+        hostId: 'test-host-123',
+        status: 'OPEN'
+      }
+    });
+
+    // 接続情報を保存するPutCommandのモックを設定
+    ddbMock.on(PutCommand).resolves({});
+
+    // テストデータ
+    const event = {
+      requestContext: {
+        connectionId: 'test-connection-id-123',
+        eventType: 'MESSAGE',
+        messageId: 'test-message-id-123'
+      },
+      body: JSON.stringify({
+        action: 'joinRoom',
+        roomId: 'test-room-123'
+      })
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // レスポンスを検証
+    expect(result.statusCode).toBe(200);
+
+    // GetCommandの呼び出しを検証
+    const getCalls = ddbMock.commandCalls(GetCommand);
+    expect(getCalls.length).toBe(1);
+    expect(getCalls[0].args[0].input.TableName).toBe('test-rooms-table');
+    expect(getCalls[0].args[0].input.Key.roomId).toBe('test-room-123');
+
+    // PutCommandの呼び出しを検証
+    const putCalls = ddbMock.commandCalls(PutCommand);
+    expect(putCalls.length).toBe(1);
+    expect(putCalls[0].args[0].input.TableName).toBe('test-connections-table');
+    expect(putCalls[0].args[0].input.Item.connectionId).toBe('test-connection-id-123');
+    expect(putCalls[0].args[0].input.Item.roomId).toBe('test-room-123');
+    expect(putCalls[0].args[0].input.Item.timestamp).toBeDefined();
+  });
+
+  test('存在しない部屋に参加しようとするとエラーになる', async () => {
+    // 部屋が存在しないケース
+    ddbMock.on(GetCommand).resolves({
+      Item: null
+    });
+
+    // テストデータ
+    const event = {
+      requestContext: {
+        connectionId: 'test-connection-id-123',
+        eventType: 'MESSAGE',
+        messageId: 'test-message-id-123'
+      },
+      body: JSON.stringify({
+        action: 'joinRoom',
+        roomId: 'non-existent-room'
+      })
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(404);
+    const body = JSON.parse(result.body);
+    expect(body.message).toContain('Room not found');
+  });
+
+  test('roomIdが指定されていない場合はエラーを返す', async () => {
+    // テストデータ（roomIdが指定されていない）
+    const event = {
+      requestContext: {
+        connectionId: 'test-connection-id-123',
+        eventType: 'MESSAGE',
+        messageId: 'test-message-id-123'
+      },
+      body: JSON.stringify({
+        action: 'joinRoom'
+      })
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.message).toContain('roomId is required');
+  });
+
+  test('DynamoDB例外が発生した場合はエラーを返す', async () => {
+    // コンソールエラーのスパイを作成
+    const consoleSpy = jest.spyOn(console, 'error');
+
+    // DynamoDBのGetCommandが例外をスローするようにモックを設定
+    ddbMock.on(GetCommand).rejects(new Error('DB Error'));
+
+    // テストデータ
+    const event = {
+      requestContext: {
+        connectionId: 'test-connection-id-123',
+        eventType: 'MESSAGE',
+        messageId: 'test-message-id-123'
+      },
+      body: JSON.stringify({
+        action: 'joinRoom',
+        roomId: 'test-room-123'
+      })
+    };
+
+    // Lambda関数を実行
+    const result = await handler(event);
+
+    // エラーレスポンスを検証
+    expect(result.statusCode).toBe(500);
+
+    // コンソールエラーの呼び出しを検証
+    expect(consoleSpy).toHaveBeenCalledWith('Error joining room:', expect.any(Error));
+
+    // スパイをリストア
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## 概要

Issue #16で指摘されていたテストが不足している部分を改善するため、Lambda関数のユニットテストを追加しました。

## 変更内容

以下の6つのLambda関数に対するユニットテストを新規作成しました：

1.  - コメント一覧を取得する関数
2.  - 部屋を閉じる関数
3.  - ユーザーの部屋一覧を取得する関数
4.  - WebSocketに接続する関数
5.  - WebSocketから切断する関数
6.  - WebSocketで部屋に参加する関数

各テストでは以下の要素を網羅しています：
- 正常系のテスト（期待通りの動作の確認）
- 異常系のテスト（パラメータ不足などのエラーハンドリング）
- データベース例外のハンドリング
- 境界条件（権限チェックなど）

また、Jest設定を修正してファイルのテストも実行できるようにしました。

## テスト結果



fixes #16